### PR TITLE
[workflow] Add the missing permissions for NPM publishing

### DIFF
--- a/.github/workflows/publishToNpm.yaml
+++ b/.github/workflows/publishToNpm.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The previous permissions were insufficient to allow the CI to push to the registry. These are based on the following documentation: [Publishing Node.js packages - Example Workflow](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#example-workflow).
